### PR TITLE
Set value in UICircularProgressRingView as well.

### DIFF
--- a/UICircularProgressRing/UICircularProgressRingView.swift
+++ b/UICircularProgressRing/UICircularProgressRingView.swift
@@ -610,6 +610,7 @@ import UIKit
                 comp()
             }
         }
+        self.value = value
         self.ringLayer.value = value
         CATransaction.commit()
     }


### PR DESCRIPTION
Hello!

I noticed that the `value` for `UICircularProgressRingView` would never get updated. A use case for the value might be in a completion block like this:

```swift
// declaration
@IBOutlet var progressBar: UICircularProgressRingView!

// later inside a function
progressBar.setProgress(value: 10, animationDuration: 10) {
  let completedValue = self.progressBar.value
  // completedValue is still 0?
}
```

Seems like `progressBar.value` was always the default value (0 in my case). We don't seem to have access to the private `ringLayer` so I thought of also setting the value in the parent view. Let me know if this sounds OK. I'm fairly new to swift so I could have missed another accessible way to grab the `value`.

Thanks!