### PR TITLE
Added value indicator to ring1 in the example project

### DIFF
--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -22,6 +22,7 @@ class ViewController: UIViewController, UICircularProgressRingDelegate  {
         // Customize some properties
         ring1.animationStyle = kCAMediaTimingFunctionLinear
         ring1.fontSize = 100
+        ring1.valueIndicator = "%"
         ring2.fontColor = UIColor.gray
         ring3.maxValue = 10
         


### PR DESCRIPTION
Spend some time wondering how to display percentage values. I was looking for valueFormatter or similar property. Ran the example project but none of the progress rings displayed percentages. 

From the documentation I found `valueIndicator`. The documentation states that `valueIndicator` has default value "%", which is true looking at the code, but progress rings still didn't display it. Didn't debug any further.

Now the first ring in the example project demonstrates how to display values as percentage.