### PR TITLE
Replace fontSize test with a font test

### DIFF
--- a/UICircularProgressRingTests/UICircularProgressRingTests.swift
+++ b/UICircularProgressRingTests/UICircularProgressRingTests.swift
@@ -119,9 +119,9 @@ class UICircularProgressRingTests: XCTestCase {
         progressRing.fontColor = UIColor.darkText
         XCTAssertEqual(progressRing.fontColor, UIColor.darkText)
         
-        XCTAssertEqual(progressRing.fontSize, 18)
-        progressRing.fontSize = 20
-        XCTAssertEqual(progressRing.fontSize, 20)
+        XCTAssertEqual(progressRing.font, UIFont.systemFont(ofSize: 18.0))
+        progressRing.font = UIFont.italicSystemFont(ofSize: 12.0)
+        XCTAssertEqual(progressRing.font, UIFont.italicSystemFont(ofSize: 12.0))
         
         XCTAssertEqual(progressRing.animationStyle, kCAMediaTimingFunctionEaseIn)
         progressRing.animationStyle = kCAMediaTimingFunctionLinear


### PR DESCRIPTION
The change to version 1.4 (fb9ac1b0) which removed the fontSize property
and added a font property did not include a change to the unit tests,
which now fail to compile due to the missing fontSize property.

This change removes the fontSize property test and adds a font test.