### PR TITLE
Update UICircularProgressRing.podspec for dependency

### DIFF
--- a/UICircularProgressRing.podspec
+++ b/UICircularProgressRing.podspec
@@ -17,8 +17,7 @@ Pod::Spec.new do |s|
   s.author             = { "Luis Padron" => "luispadronedu@gmail.com" }
   s.social_media_url   = "https://luispadron.com"
 
-  s.platform     = :ios, "8.0"
-
+  s.ios.deployment_target = "8.0"
   s.source       = { :git => "https://github.com/luispadron/UICircularProgressRing.git", :tag => "v#{s.version}" }
 
   s.source_files  = "UICircularProgressRing", "UICircularProgressRing/**/*.{h,m}"


### PR DESCRIPTION
Hello, I use your library in [MediaBrowser](https://github.com/younatics/MediaBrowser)

In your Podspec, there is no deployment target so I can't build travis in my libs.
Could you update for me?

Thanks!