### PR TITLE
Improved Calculations for Inner Ring Angle

### DIFF
--- a/UICircularProgressRing/UICircularProgressRingLayer.swift
+++ b/UICircularProgressRing/UICircularProgressRingLayer.swift
@@ -220,7 +220,7 @@ class UICircularProgressRingLayer: CAShapeLayer {
             innerEndAngle = (value - minValue) / (maxValue - minValue) * 360.0 + startAngle
         } else {
             // Calculate the center difference between the end and start angle
-            let angleDiff: CGFloat = (startAngle > endAngle) ? (360 - startAngle + endAngle) : (endAngle - startAngle) 
+            let angleDiff: CGFloat = (startAngle > endAngle) ? (360.0 - startAngle + endAngle) : (endAngle - startAngle) 
             // Calculate how much we should draw depending on the value set
             innerEndAngle = (value - minValue) / (maxValue - minValue) * angleDiff + startAngle
         }

--- a/UICircularProgressRing/UICircularProgressRingLayer.swift
+++ b/UICircularProgressRing/UICircularProgressRingLayer.swift
@@ -217,12 +217,12 @@ class UICircularProgressRingLayer: CAShapeLayer {
         let innerEndAngle: CGFloat
         
         if fullCircle {
-            innerEndAngle = (value - minValue) / maxValue * 360.0 + startAngle
+            innerEndAngle = (value - minValue) / (maxValue - minValue) * 360.0 + startAngle
         } else {
             // Calculate the center difference between the end and start angle
-            let angleDiff: CGFloat = abs(endAngle - startAngle)
+            let angleDiff: CGFloat = (startAngle > endAngle) ? (360 - startAngle + endsAngle) : (endAngle - startAngle) 
             // Calculate how much we should draw depending on the value set
-            innerEndAngle = (value - minValue) / maxValue * angleDiff + startAngle
+            innerEndAngle = (value - minValue) / (maxValue - minValue) * angleDiff + startAngle
         }
         
         // The radius for style 1 is set below

--- a/UICircularProgressRing/UICircularProgressRingLayer.swift
+++ b/UICircularProgressRing/UICircularProgressRingLayer.swift
@@ -220,7 +220,7 @@ class UICircularProgressRingLayer: CAShapeLayer {
             innerEndAngle = (value - minValue) / (maxValue - minValue) * 360.0 + startAngle
         } else {
             // Calculate the center difference between the end and start angle
-            let angleDiff: CGFloat = (startAngle > endAngle) ? (360 - startAngle + endsAngle) : (endAngle - startAngle) 
+            let angleDiff: CGFloat = (startAngle > endAngle) ? (360 - startAngle + endAngle) : (endAngle - startAngle) 
             // Calculate how much we should draw depending on the value set
             innerEndAngle = (value - minValue) / (maxValue - minValue) * angleDiff + startAngle
         }


### PR DESCRIPTION
I was having problems with the ring not being drawn at the right value in my project, so I decided to look through UICircularProgressRingLayer.drawInnerRing() and I found that the calculation for innerEndAngle wasn't handling when the startAngle is greater than endAngle (which was causing my problem). I fixed this, and as a bonus, the code now handles when the minValue isn't 0

Main commit:
        1956ca5 — Improved calculations for innerEndAngle in func UICircularProgressRingLayer.drawInnerRing when minValue not 0 and/or when startAngle > endAngle