### PR TITLE
Add Carthage IB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,6 @@
 
 ### Carthage
 
-**_Important note_: Carthage support for IBDesignable and IBInspectable is broken due to how frameworks work.
-So if you decide on using Carthage, you will not be able to use IB to design this view.
-Take a look [here](https://github.com/Carthage/Carthage/issues/335) for the issue.**
-
 To use with [Carthage](https://github.com/Carthage/Carthage)
 
 1. Make sure Carthage is installed 

--- a/UICircularProgressRing.xcodeproj/project.pbxproj
+++ b/UICircularProgressRing.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9E699E1B202B010F00B83D94 /* UICircularProgressRingView.swift in Headers */ = {isa = PBXBuildFile; fileRef = A0C6DE9C1D88CCFD008AE742 /* UICircularProgressRingView.swift */; settings = {ATTRIBUTES = (Public, ); }; };
 		A0094D341DA4473B0074805C /* UICircularProgressRingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0094D331DA4473B0074805C /* UICircularProgressRingDelegate.swift */; };
 		A01A67581D8F55D700AC8CAD /* UICircularProgressRingLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01A67571D8F55D700AC8CAD /* UICircularProgressRingLayer.swift */; };
 		A0C6DE861D88CBE2008AE742 /* UICircularProgressRing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A0C6DE7C1D88CBE1008AE742 /* UICircularProgressRing.framework */; };
@@ -109,6 +110,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A0C6DE8D1D88CBE2008AE742 /* UICircularProgressRing.h in Headers */,
+				9E699E1B202B010F00B83D94 /* UICircularProgressRingView.swift in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Adds UICircularProgressRingView.swift to the library public headers, as can be seen here: https://github.com/Carthage/Carthage/issues/335#issuecomment-271473161. This adds support for IBDesignable / IBInspectable using Carthage.