### PR TITLE
Mark delegate methods as optional

### DIFF
--- a/UICircularProgressRing/UICircularProgressRingDelegate.swift
+++ b/UICircularProgressRing/UICircularProgressRingDelegate.swift
@@ -45,7 +45,7 @@ import UIKit
      - Parameter ring: The ring which finished animating
      
     */
-    @objc func finishedUpdatingProgress(forRing ring: UICircularProgressRingView)
+    @objc optional func finishedUpdatingProgress(forRing ring: UICircularProgressRingView)
 
     /**
      This method is called whenever the value is updated, this means during animation this method will be called in real time.
@@ -59,7 +59,7 @@ import UIKit
 
      - Paramater newValue: The value which the ring has updated to
      */
-    @objc func didUpdateProgressValue(to newValue: CGFloat)
+    @objc optional func didUpdateProgressValue(to newValue: CGFloat)
     
     /**
      This method is called whenever the label is about to be drawn.
@@ -67,10 +67,4 @@ import UIKit
      
     */
     @objc optional func willDisplayLabel(label: UILabel)
-}
-
-extension UICircularProgressRingDelegate {
-    // Default conformance
-    func finishedUpdatingProgress(forRing ring: UICircularProgressRingView) { }
-    func didUpdateProgressValue(to newValue: CGFloat) { }
 }

--- a/UICircularProgressRing/UICircularProgressRingView.swift
+++ b/UICircularProgressRing/UICircularProgressRingView.swift
@@ -794,7 +794,7 @@ import UIKit
      the `newValue` so that it notifies any delegates who may need to know about value updates in real time
      */
     internal func didUpdateValue(newValue: CGFloat) {
-        delegate?.didUpdateProgressValue(to: newValue)
+        delegate?.didUpdateProgressValue?(to: newValue)
     }
     
     internal func willDisplayLabel(label: UILabel) {
@@ -833,7 +833,7 @@ import UIKit
         CATransaction.begin()
         CATransaction.setCompletionBlock {
             // Call the closure block
-            self.delegate?.finishedUpdatingProgress(forRing: self)
+            self.delegate?.finishedUpdatingProgress?(forRing: self)
             completion?()
         }
 


### PR DESCRIPTION
Marking a protocol and its methods as @objc makes the default conformance extension to be ignored. Marking the default conformance extension as @objc does not work. Making the methods optional instead (which is now available, as the methods are marked as @objc) fixes this, providing the same results as before when using a delegate without implementing all methods.