### PR TITLE
Adds support for anticlockwise circle draw

### DIFF
--- a/src/UICircularProgressRing/UICircularProgressRingLayer.swift
+++ b/src/UICircularProgressRing/UICircularProgressRingLayer.swift
@@ -4,14 +4,14 @@
 //
 //  Copyright (c) 2016 Luis Padron
 //
-//  Permission is hereby granted, free of charge, to any person obtaining a 
-//  copy of this software and associated documentation files (the "Software"), 
-//  to deal in the Software without restriction, including without limitation the 
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation the
 //  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 //  copies of the Software, and to permit persons to whom the Software is furnished
 //  to do so, subject to the following conditions:
 //
-//  The above copyright notice and this permission notice shall be included 
+//  The above copyright notice and this permission notice shall be included
 // in all copies or substantial portions of the Software.
 //
 //  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
@@ -64,7 +64,7 @@ private extension UILabel {
 /**
  The internal subclass for CAShapeLayer.
  This is the class that handles all the drawing and animation.
- This class is not interacted with, instead 
+ This class is not interacted with, instead
  properties are set in UICircularProgressRingView and those are delegated to here.
  
  */
@@ -110,6 +110,7 @@ class UICircularProgressRingLayer: CAShapeLayer {
     @NSManaged var rightToLeft: Bool
     @NSManaged var showFloatingPoint: Bool
     @NSManaged var decimalPlaces: Int
+    @NSManaged var isClockwise: Bool
     
     var animationDuration: TimeInterval = 1.0
     var animationStyle: String = kCAMediaTimingFunctionEaseInEaseOut
@@ -251,16 +252,24 @@ class UICircularProgressRingLayer: CAShapeLayer {
         let innerEndAngle: CGFloat
         
         if fullCircle {
-            innerEndAngle = (value - minValue) / (maxValue - minValue) * 360.0 + startAngle
+            if (!isClockwise) {
+                innerEndAngle = startAngle - ((value - minValue) / (maxValue - minValue) * 360.0)
+            } else {
+                innerEndAngle = (value - minValue) / (maxValue - minValue) * 360.0 + startAngle
+            }
         } else {
             // Calculate the center difference between the end and start angle
-            let angleDiff: CGFloat = (startAngle > endAngle) ? (360.0 - startAngle + endAngle) : (endAngle - startAngle) 
+            let angleDiff: CGFloat = (startAngle > endAngle) ? (360.0 - startAngle + endAngle) : (endAngle - startAngle)
             // Calculate how much we should draw depending on the value set
-            innerEndAngle = (value - minValue) / (maxValue - minValue) * angleDiff + startAngle
+            if (!isClockwise) {
+                innerEndAngle = startAngle - ((value - minValue) / (maxValue - minValue) * angleDiff)
+            } else {
+                innerEndAngle = (value - minValue) / (maxValue - minValue) * angleDiff + startAngle
+            }
         }
         
         // The radius for style 1 is set below
-        // The radius for style 1 is a bit less than the outer, 
+        // The radius for style 1 is a bit less than the outer,
         // this way it looks like its inside the circle
         
         var radiusIn: CGFloat = 0.0
@@ -280,7 +289,7 @@ class UICircularProgressRingLayer: CAShapeLayer {
                                                    radius: radiusIn,
                                                    startAngle: startAngle.toRads,
                                                    endAngle: innerEndAngle.toRads,
-                                                   clockwise: true)
+                                                   clockwise: isClockwise)
         
         // Draw path
         ctx.setLineWidth(innerRingWidth)

--- a/src/UICircularProgressRing/UICircularProgressRingView.swift
+++ b/src/UICircularProgressRing/UICircularProgressRingView.swift
@@ -27,7 +27,7 @@ import UIKit
 
 /**
  
- # UICiruclarProgressRingView
+ # UICircularProgressRingView
  
  This is the UIView subclass that creates and handles everything
  to do with the progress ring
@@ -35,7 +35,7 @@ import UIKit
  This class has a custom CAShapeLayer (UICircularProgressRingLayer) which
  handels the drawing and animating of the view
  
- The properties in this class correspond with the 
+ The properties in this class correspond with the
  properties in UICircularProgressRingLayer.
  When they are set in here, they are also set for the layer and drawn accordingly
  
@@ -55,7 +55,7 @@ import UIKit
      When progress is done updating via UICircularProgressRingView.setValue(_:), the
      finishedUpdatingProgressFor(_ ring: UICircularProgressRingView) will be called.
      
-     The ring will be passed to the delegate in order to keep track of 
+     The ring will be passed to the delegate in order to keep track of
      multiple ring updates if needed.
      
      ## Author
@@ -68,7 +68,7 @@ import UIKit
     /**
      Whether or not the progress ring should be a full circle.
      
-     What this means is that the outer ring will always go from 0 - 360 degrees and 
+     What this means is that the outer ring will always go from 0 - 360 degrees and
      the inner ring will be calculated accordingly depending on current value.
      
      ## Important ##
@@ -79,7 +79,7 @@ import UIKit
      ## Author
      Luis Padron
      
-    */
+     */
     @IBInspectable open var fullCircle: Bool = true {
         didSet {
             self.ringLayer.fullCircle = self.fullCircle
@@ -97,10 +97,10 @@ import UIKit
      Must be a non-negative value. If this value falls below `minValue` it will be
      clamped and set equal to `minValue`.
      
-     This cannot be used to get the value while the ring is animating, to get 
+     This cannot be used to get the value while the ring is animating, to get
      current value while animating use `currentValue`.
      
-     The current value of the progress ring after animating, use setProgress(value:) 
+     The current value of the progress ring after animating, use setProgress(value:)
      to alter the value with the option to animate and have a completion handler.
      
      ## Author
@@ -120,9 +120,9 @@ import UIKit
     /**
      The current value of the progress ring
      
-     This will return the current value of the progress ring, 
+     This will return the current value of the progress ring,
      if the ring is animating it will be updated in real time.
-     If the ring is not currently animating then the value returned 
+     If the ring is not currently animating then the value returned
      will be the `value` property of the ring
      
      ## Author
@@ -178,6 +178,22 @@ import UIKit
     @IBInspectable open var maxValue: CGFloat = 100.0 {
         didSet {
             self.ringLayer.maxValue = abs(self.maxValue)
+        }
+    }
+    
+    /**
+     The direction the circle is drawn in
+     Example: true -> clockwise
+     
+     ## Important ##
+     Default = true (draw the circle clockwise)
+     
+     ## Author
+     Pete Walker
+     */
+    @IBInspectable open var isClockwise: Bool = true {
+        didSet {
+            self.ringLayer.isClockwise = self.isClockwise
         }
     }
     
@@ -592,7 +608,7 @@ import UIKit
     
     /**
      The font to be used for the progress indicator.
-     All font attributes are specified here except for font color, which is done 
+     All font attributes are specified here except for font color, which is done
      using `fontColor`.
      
      
@@ -763,6 +779,7 @@ import UIKit
         self.layer.masksToBounds = false
         
         self.ringLayer.fullCircle = fullCircle
+        self.ringLayer.isClockwise = isClockwise
         
         self.ringLayer.value = value
         self.ringLayer.maxValue = maxValue
@@ -819,20 +836,20 @@ import UIKit
     
     /**
      Typealias for the setProgress(:) method closure
-    */
+     */
     public typealias ProgressCompletion = (() -> Void)
     
     /**
-     Sets the current value for the progress ring, calling this method while ring is 
+     Sets the current value for the progress ring, calling this method while ring is
      animating will cancel the previously set animation and start a new one.
      
-     - Parameter newVal: The value to be set for the progress ring
-     - Parameter animationDuration: The time interval duration for the animation
-     - Parameter completion: The completion closure block that will be called when 
+     - Parameter to: The value to be set for the progress ring
+     - Parameter duration: The time interval duration for the animation
+     - Parameter completion: The completion closure block that will be called when
      animtion is finished (also called when animationDuration = 0), default is nil
      
      ## Important ##
-     Animatin duration = 0 will cause no animation to occur, and value will instantly 
+     Animation duration = 0 will cause no animation to occur, and value will instantly
      be set
      
      ## Author
@@ -855,7 +872,7 @@ import UIKit
         self.value = value
         CATransaction.commit()
     }
-
+    
     /**
      Typealias for animateProperties(duration:animations:completion:) fucntion completion
      */

--- a/src/UICircularProgressRingTests/UICircularProgressRingTests.swift
+++ b/src/UICircularProgressRingTests/UICircularProgressRingTests.swift
@@ -24,16 +24,16 @@ class UICircularProgressRingTests: XCTestCase {
     
     func testApiAndAnimations() {
         
-        progressRing.setProgress(value: 23.1, animationDuration: 0)
+        progressRing.setProgress(to: 23.1, duration: 0)
         XCTAssertEqual(progressRing.value, 23.1)
         
-        progressRing.setProgress(value: 17.9, animationDuration: 0, completion: nil)
+        progressRing.setProgress(to: 17.9, duration: 0, completion: nil)
         XCTAssertEqual(progressRing.value, 17.9)
         
-        progressRing.setProgress(value: 100, animationDuration: 0.2) {
+        progressRing.setProgress(to: 100, duration: 0.2) {
             XCTAssertEqual(self.progressRing.value, 100)
             XCTAssertEqual(self.progressRing.isAnimating, false)
-            self.progressRing.setProgress(value: 25.32, animationDuration: 0.3, completion: {
+            self.progressRing.setProgress(to: 25.32, duration: 0.3, completion: {
                 XCTAssertEqual(self.progressRing.value, 25.32)
                 XCTAssertEqual(self.progressRing.isAnimating, false)
             })


### PR DESCRIPTION
This commit adds a new `isClockwise` boolean property to `UICircularProgressRingView`,
that allows you to draw the circle in either clockwise or anticlockwise direction.

Note that this DOES NOT affect the geometry used when specifiying the `startAngle`.

This commit also fixes some failing tests, and adds a little documentation clean-up.