### PR TITLE
Added new ring style: bordered.

### DIFF
--- a/src/UICircularProgressRing/UICircularProgressRing.swift
+++ b/src/UICircularProgressRing/UICircularProgressRing.swift
@@ -513,6 +513,36 @@ fileprivate extension CALayer {
     }
     
     /**
+     The color for the outer ring border
+     
+     ## Important ##
+     Default = UIColor.gray
+     
+     ## Author
+     Abdulla Allaith
+     */
+    @IBInspectable open var outerBorderColor: UIColor = UIColor.gray {
+        didSet {
+            ringLayer.outerBorderColor = outerBorderColor
+        }
+    }
+    
+    /**
+     The width for the outer ring border
+     
+     ## Important ##
+     Default = 2
+     
+     ## Author
+     Abdulla Allaith
+     */
+    @IBInspectable open var outerBorderWidth: CGFloat = 2 {
+        didSet {
+            ringLayer.outerBorderWidth = outerBorderWidth
+        }
+    }
+    
+    /**
      The style for the outer ring end cap (how it is drawn on screen)
      Range [1,3]
      - 1: Line with a squared off end
@@ -940,6 +970,8 @@ fileprivate extension CALayer {
         
         ringLayer.outerRingWidth = outerRingWidth
         ringLayer.outerRingColor = outerRingColor
+        ringLayer.outerBorderWidth = outerBorderWidth
+        ringLayer.outerBorderColor = outerBorderColor
         ringLayer.outerCapStyle = outerCapStyle
         
         ringLayer.innerRingWidth = innerRingWidth

--- a/src/UICircularProgressRing/UICircularProgressRingLayer.swift
+++ b/src/UICircularProgressRing/UICircularProgressRingLayer.swift
@@ -103,6 +103,8 @@ class UICircularProgressRingLayer: CAShapeLayer {
     @NSManaged var outerRingWidth: CGFloat
     @NSManaged var outerRingColor: UIColor
     @NSManaged var outerCapStyle: CGLineCap
+    @NSManaged var outerBorderColor: UIColor
+    @NSManaged var outerBorderWidth: CGFloat
     
     @NSManaged var innerRingWidth: CGFloat
     @NSManaged var innerRingColor: UIColor
@@ -238,6 +240,32 @@ class UICircularProgressRingLayer: CAShapeLayer {
         case .dotted:
             outerPath.setLineDash([0, outerPath.lineWidth * 2], count: 2, phase: 0)
             outerPath.lineCapStyle = .round
+        
+        case .bordered:
+            let innerBorder = CAShapeLayer()
+            self.addSublayer(innerBorder)
+            
+            let roundedRect1 = outerPath.bounds.insetBy(dx: outerRingWidth/2, dy: outerRingWidth/2)
+            let path1 =
+                UIBezierPath(roundedRect: roundedRect1, cornerRadius: outerRadius)
+            innerBorder.path = path1.cgPath
+            innerBorder.fillColor = UIColor.clear.cgColor
+            
+            innerBorder.strokeColor = outerBorderColor.cgColor
+            innerBorder.lineWidth = outerBorderWidth
+            
+            
+            let outerBorder = CAShapeLayer()
+            self.addSublayer(outerBorder)
+            
+            let roundedRect2 = outerPath.bounds.insetBy(dx: -outerRingWidth/2, dy: -outerRingWidth/2)
+            let path2 =
+                UIBezierPath(roundedRect: roundedRect2, cornerRadius: outerRadius)
+            outerBorder.path = path2.cgPath
+            outerBorder.fillColor = UIColor.clear.cgColor
+            
+            outerBorder.strokeColor = outerBorderColor.cgColor
+            outerBorder.lineWidth = outerBorderWidth
             
         default: break
             

--- a/src/UICircularProgressRing/UICircularProgressRingStyle.swift
+++ b/src/UICircularProgressRing/UICircularProgressRingStyle.swift
@@ -44,4 +44,6 @@
     case dotted = 4
     /// Inner ring is placed ontop of the outer ring and it has a gradient
     case gradient = 5
+    /// Inner ring is placed ontop of the outer ring and outer ring has border
+    case bordered = 6
 }

--- a/src/UICircularProgressRingTests/UICircularProgressRingTests.swift
+++ b/src/UICircularProgressRingTests/UICircularProgressRingTests.swift
@@ -72,6 +72,10 @@ class UICircularProgressRingTests: XCTestCase {
         XCTAssertEqual(progressRing.ringStyle, .ontop)
         XCTAssertEqual(progressRing.ringLayer.ringStyle, .ontop)
         
+        progressRing.ringStyle = .bordered
+        XCTAssertEqual(progressRing.ringStyle, .bordered)
+        XCTAssertEqual(progressRing.ringLayer.ringStyle, .bordered)
+        
         progressRing.patternForDashes = [6.0, 5.0]
         XCTAssertEqual(progressRing.patternForDashes, [6.0, 5.0])
         XCTAssertEqual(progressRing.ringLayer.patternForDashes, [6.0, 5.0])
@@ -131,6 +135,14 @@ class UICircularProgressRingTests: XCTestCase {
         progressRing.outerRingColor = UIColor.red
         XCTAssertEqual(progressRing.outerRingColor, UIColor.red)
         XCTAssertEqual(progressRing.ringLayer.outerRingColor, UIColor.red)
+        
+        progressRing.outerBorderWidth = 5
+        XCTAssertEqual(progressRing.outerBorderWidth, 5)
+        XCTAssertEqual(progressRing.ringLayer.outerBorderWidth, 5)
+        
+        progressRing.outerBorderColor = UIColor.red
+        XCTAssertEqual(progressRing.outerBorderColor, UIColor.red)
+        XCTAssertEqual(progressRing.ringLayer.outerBorderColor, UIColor.red)
         
         progressRing.outerCapStyle = .round
         XCTAssertEqual(progressRing.outerCapStyle, .round)


### PR DESCRIPTION
Added the feature requested in #28                    
New ring style: Bordered.               
It adds inner ring `ontop` outer ring, and adds border to the outer ring.                  
The new properties `OuterBorderColor` and `OuterBorderWidth` allow control of width/color of the border.                                    

![image](https://user-images.githubusercontent.com/29616360/43420384-2c451d1a-944c-11e8-9b5b-9c5533428141.png)

