### PR TITLE
#122 Pause and Reset no longer call the completion block prematurely

### DIFF
--- a/src/UICircularProgressRing.xcodeproj/project.pbxproj
+++ b/src/UICircularProgressRing.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		A0C6DE8D1D88CBE2008AE742 /* UICircularProgressRing.h in Headers */ = {isa = PBXBuildFile; fileRef = A0C6DE7F1D88CBE1008AE742 /* UICircularProgressRing.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A0E0ED771EE782620034062A /* UICircularProgressRingGradientPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0E0ED751EE782490034062A /* UICircularProgressRingGradientPosition.swift */; };
 		A0E0ED781EE782650034062A /* UICircularProgressRingStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0E0ED761EE782490034062A /* UICircularProgressRingStyle.swift */; };
+		AB8F17E5212522C100CFB95E /* UICircularProgressRingPauseResetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB8F17E4212522C100CFB95E /* UICircularProgressRingPauseResetTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,6 +40,7 @@
 		A0C6DE8C1D88CBE2008AE742 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A0E0ED751EE782490034062A /* UICircularProgressRingGradientPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICircularProgressRingGradientPosition.swift; sourceTree = "<group>"; };
 		A0E0ED761EE782490034062A /* UICircularProgressRingStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UICircularProgressRingStyle.swift; sourceTree = "<group>"; };
+		AB8F17E4212522C100CFB95E /* UICircularProgressRingPauseResetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICircularProgressRingPauseResetTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,6 +97,7 @@
 		A0C6DE891D88CBE2008AE742 /* UICircularProgressRingTests */ = {
 			isa = PBXGroup;
 			children = (
+				AB8F17E4212522C100CFB95E /* UICircularProgressRingPauseResetTests.swift */,
 				A0C6DE8A1D88CBE2008AE742 /* UICircularProgressRingTests.swift */,
 				A0C6DE8C1D88CBE2008AE742 /* Info.plist */,
 			);
@@ -227,6 +230,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AB8F17E5212522C100CFB95E /* UICircularProgressRingPauseResetTests.swift in Sources */,
 				A0C6DE8B1D88CBE2008AE742 /* UICircularProgressRingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/UICircularProgressRing/UICircularProgressRing.swift
+++ b/src/UICircularProgressRing/UICircularProgressRing.swift
@@ -873,10 +873,10 @@ fileprivate extension CALayer {
     private var animationPauseTime: CFTimeInterval?
     
     /// The completion timer, also indicates wether or not the view is animating
-    fileprivate var completionTimer: Timer?
+    private var completionTimer: Timer?
     
     /// The completion block to call after the animation is done
-    fileprivate var completion: ProgressCompletion?
+    private var completion: ProgressCompletion?
     
     // MARK: Layer
     
@@ -1099,11 +1099,9 @@ fileprivate extension CALayer {
         ringLayer.speed = 0.0
         
         //Cancel the timer, it will have to be re-created when we continue the progress
-        if let completionTimer = completionTimer {
-            completionTimer.invalidate()
-            self.completionTimer = nil
-        }
-
+        completionTimer?.invalidate()
+        self.completionTimer = nil
+        
         delegate?.didPauseProgress?(for: self)
     }
 
@@ -1154,10 +1152,8 @@ fileprivate extension CALayer {
         value = minValue
         
         //Stop the timer and thus make the completion method not get fired
-        if let completionTimer = completionTimer {
-            completionTimer.invalidate()
-            self.completionTimer = nil
-        }
+        completionTimer?.invalidate()
+        self.completionTimer = nil
     }
 
 

--- a/src/UICircularProgressRing/UICircularProgressRing.swift
+++ b/src/UICircularProgressRing/UICircularProgressRing.swift
@@ -1055,10 +1055,8 @@ fileprivate extension CALayer {
         self.completion = completion
         
         //Check if a completion timer is still active and if so stop it
-        if let completionTimer = completionTimer {
-            completionTimer.invalidate()
-            self.completionTimer = nil
-        }
+        completionTimer?.invalidate()
+        self.completionTimer = nil
         
         //Create a new completion timer
         completionTimer = Timer.scheduledTimer(timeInterval: duration,

--- a/src/UICircularProgressRing/UICircularProgressRing.swift
+++ b/src/UICircularProgressRing/UICircularProgressRing.swift
@@ -849,7 +849,6 @@ fileprivate extension CALayer {
      */
     @objc open var isAnimating: Bool {
         get {
-//            return (layer.animation(forKey: .value) != nil) ? true : false
             return completionTimer?.isValid ?? false
         }
     }
@@ -872,6 +871,12 @@ fileprivate extension CALayer {
 
     /// Used to determine when the animation was paused
     private var animationPauseTime: CFTimeInterval?
+    
+    /// The completion timer, also indicates wether or not the view is animating
+    fileprivate var completionTimer: Timer?
+    
+    /// The completion block to call after the animation is done
+    fileprivate var completion: ProgressCompletion?
     
     // MARK: Layer
     
@@ -1010,9 +1015,6 @@ fileprivate extension CALayer {
         delegate?.willDisplayLabel?(for: self, label)
     }
 
-    fileprivate var completionTimer: Timer?
-    fileprivate var completion: ProgressCompletion?
-    
     /**
      Sets the current value for the progress ring, calling this method while ring is
      animating will cancel the previously set animation and start a new one.
@@ -1070,6 +1072,7 @@ fileprivate extension CALayer {
     }
     
     @objc func didCompleteWithCompletion(_ completion: Timer) {
+        //Call the completion event and block
         self.delegate?.didFinishProgress?(for: self)
         (completion.userInfo as? ProgressCompletion)?()
     }

--- a/src/UICircularProgressRingTests/UICircularProgressRingPauseResetTests.swift
+++ b/src/UICircularProgressRingTests/UICircularProgressRingPauseResetTests.swift
@@ -1,0 +1,89 @@
+//
+//  UICircularProgressRingPauseResetTests.swift
+//  UICircularProgressRingTests
+//
+//  Created by Miley Hollenberg on 15/08/2018.
+//  Copyright © 2018 Luis Padron. All rights reserved.
+//
+
+//A seperate test case just for the completion block, since it's a timing based test it does not work will with the other regular tests
+//It does require the use of usleep (or a different sleep method) to ensure that the pauseProgress actually has any effect and isn't premeturely firing it's completion block
+
+import Foundation
+
+import XCTest
+@testable import UICircularProgressRing
+
+class UICircularProgressRingPauseResetTests: XCTestCase {
+    
+    var progressRing: UICircularProgressRing!
+    
+    override func setUp() {
+        super.setUp()
+        progressRing = UICircularProgressRing(frame: CGRect(x: 0, y: 0, width: 100, height: 200))
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testProgressCompletionBlock() {
+        //* Test the resetProgress
+        //Start the progress
+        progressRing.startProgress(to: 100, duration: 0.1, completion: {
+            //Should not be called due to the resetProgress
+            XCTAssert(false)
+        })
+        
+        //Reset the progress
+        progressRing.resetProgress()
+        
+        
+        
+        //* Test the happy flow after the initial reset to ensure that nothing has been broken by the reset
+        //Create an expectation
+        let normalExpectation = self.expectation(description: "Completion on reset")
+        
+        //Start a new progress animation
+        progressRing.startProgress(to: 100, duration: 0.1, completion: {
+            //Should not be called due to the resetProgress
+            normalExpectation.fulfill()
+        })
+        
+        //Wait for the expactation to fulfill or not
+        waitForExpectations(timeout: 0.2, handler: nil)
+        
+        
+        
+        //* Test the pauseProgress
+        //Store the current time to compare later on
+        let startTime = CACurrentMediaTime()
+        var stopTime: CFTimeInterval?
+        
+        //Create a new expectation
+        let pauseExpectation = self.expectation(description: "Completion after pause")
+        
+        //Start a new progress animation
+        progressRing.startProgress(to: 100, duration: 0.1, completion: {
+            //Should be called later than the 0.1 duration, this will be checked at the end of this test
+            pauseExpectation.fulfill()
+            stopTime = CACurrentMediaTime()
+        })
+        
+        //Pause the animation
+        progressRing.pauseProgress()
+        
+        //Sleep for 0.1 second
+        usleep(100 * 1000)
+        
+        //Restart the animation
+        progressRing.continueProgress()
+        
+        //Wait for the excpectation
+        waitForExpectations(timeout: 0.11, handler: nil)
+        
+        //Check the time difference between the start and stop times
+        let difference = stopTime! - startTime
+        XCTAssertGreaterThan(difference, 0.2)
+    }
+}

--- a/src/UICircularProgressRingTests/UICircularProgressRingPauseResetTests.swift
+++ b/src/UICircularProgressRingTests/UICircularProgressRingPauseResetTests.swift
@@ -46,11 +46,11 @@ class UICircularProgressRingPauseResetTests: XCTestCase {
         
         //Start a new progress animation
         progressRing.startProgress(to: 100, duration: 0.1, completion: {
-            //Should not be called due to the resetProgress
+            //Should be called
             normalExpectation.fulfill()
         })
         
-        //Wait for the expactation to fulfill or not
+        //Wait for the expactation to fulfill
         waitForExpectations(timeout: 0.2, handler: nil)
         
         


### PR DESCRIPTION
I had to change the way the completion block was called entirely due to the fact that inside a CATransition you cannot pause or cancel the completion block after the transition has been committed. This new approach works via the Timer class and does allow for pausing and resetting any animations. Since you can only have 1 animation running at a time it automatically resets the completion block when a new startProgress is called.

I've also created a new test case script to make sure the intended behaviour works and doesn't break the original functionality. This test case was put into a separate file due to it having to make use of usleep which broke the other tests running simultaneously (the use of usleep is required however to ensure the pause actually pauses the animation and doesn't just fake it)