### PR TITLE
Fixed animation pause/continue-logic and fatal halts

### DIFF
--- a/src/UICircularProgressRing/UICircularProgressRing.swift
+++ b/src/UICircularProgressRing/UICircularProgressRing.swift
@@ -35,11 +35,11 @@ fileprivate extension CALayer {
     func removeAnimation(forKey key: AnimationKeys) {
         removeAnimation(forKey: key.rawValue)
     }
-
+    
     func animation(forKey key: AnimationKeys) -> CAAnimation? {
         return animation(forKey: key.rawValue)
     }
-
+    
     func value(forKey key: AnimationKeys) -> Any? {
         return value(forKey: key.rawValue)
     }
@@ -66,7 +66,7 @@ fileprivate extension CALayer {
  
  */
 @IBDesignable open class UICircularProgressRing: UIView {
-
+    
     // MARK: Delegate
     /**
      The delegate for the UICircularProgressRing
@@ -82,9 +82,9 @@ fileprivate extension CALayer {
      Luis Padron
      */
     @objc open weak var delegate: UICircularProgressRingDelegate?
-
+    
     // MARK: Circle Properties
-
+    
     /**
      Whether or not the progress ring should be a full circle.
      
@@ -105,15 +105,15 @@ fileprivate extension CALayer {
             ringLayer.fullCircle = fullCircle
         }
     }
-
+    
     // MARK: Value Properties
-
+    
     /**
      The value property for the progress ring.
      
      ## Important ##
      Default = 0
-
+     
      Must be a non-negative value. If this value falls below `minValue` it will be
      clamped and set equal to `minValue`.
      
@@ -136,7 +136,7 @@ fileprivate extension CALayer {
             ringLayer.value = value
         }
     }
-
+    
     /**
      The current value of the progress ring
      
@@ -155,20 +155,20 @@ fileprivate extension CALayer {
             return value
         }
     }
-
+    
     /**
      The minimum value for the progress ring. ex: (0) -> 100.
-
+     
      ## Important ##
      Default = 100
-
+     
      Must be a non-negative value, the absolute value is taken when setting this property.
-
+     
      The `value` of the progress ring must NOT fall below `minValue` if it does the `value` property is clamped
      and will be set equal to `value`, you will receive a warning message in the console.
-
+     
      Making this value greater than
-
+     
      ## Author
      Luis Padron
      */
@@ -177,15 +177,15 @@ fileprivate extension CALayer {
             ringLayer.minValue = abs(minValue)
         }
     }
-
+    
     /**
      The maximum value for the progress ring. ex: 0 -> (100)
      
      ## Important ##
      Default = 100
-
+     
      Must be a non-negative value, the absolute value is taken when setting this property.
-
+     
      Unlike the `minValue` member `value` can extend beyond `maxValue`. What happens in this case
      is the inner ring will do an extra loop through the outer ring, this is not noticible however.
      
@@ -198,9 +198,9 @@ fileprivate extension CALayer {
             ringLayer.maxValue = abs(maxValue)
         }
     }
-
+    
     // MARK: View Style
-
+    
     /**
      Variable for the style of the progress ring.
      
@@ -231,7 +231,7 @@ fileprivate extension CALayer {
             ringStyle = style ?? .inside
         }
     }
-
+    
     /**
      The style of the progress ring.
      
@@ -250,13 +250,13 @@ fileprivate extension CALayer {
             ringLayer.ringStyle = ringStyle
         }
     }
-
+    
     /**
      Whether or not the value knob is shown
-
+     
      ## Important ##
      Default = false
-
+     
      ## Author
      Luis Padron
      */
@@ -265,13 +265,13 @@ fileprivate extension CALayer {
             ringLayer.showsValueKnob = showsValueKnob
         }
     }
-
+    
     /**
      The size of the value knob (diameter)
-
+     
      ## Important ##
      Default = 15
-
+     
      ## Author
      Luis Padron
      */
@@ -280,13 +280,13 @@ fileprivate extension CALayer {
             ringLayer.valueKnobSize = valueKnobSize
         }
     }
-
+    
     /**
      The color of the value knob
-
+     
      ## Important ##
      Default = UIColor.lightGray
-
+     
      ## Author
      Luis Padron
      */
@@ -295,7 +295,7 @@ fileprivate extension CALayer {
             ringLayer.valueKnobColor = valueKnobColor
         }
     }
-
+    
     /**
      The blur (size) of the value knob's shadow
      
@@ -310,7 +310,7 @@ fileprivate extension CALayer {
             ringLayer.valueKnobShadowBlur = valueKnobShadowBlur
         }
     }
-
+    
     /**
      The offset of the value knob's shadow
      
@@ -325,7 +325,7 @@ fileprivate extension CALayer {
             ringLayer.valueKnobShadowOffset = valueKnobShadowOffset
         }
     }
-
+    
     /**
      The color of the value knob's shadow
      
@@ -340,7 +340,7 @@ fileprivate extension CALayer {
             ringLayer.valueKnobShadowColor = valueKnobShadowColor
         }
     }
-
+    
     /**
      An array of CGFloats, used to calculate the dash length for viewStyle = 3
      
@@ -355,7 +355,7 @@ fileprivate extension CALayer {
             ringLayer.patternForDashes = patternForDashes
         }
     }
-
+    
     /**
      The start angle for the entire progress ring view.
      
@@ -375,7 +375,7 @@ fileprivate extension CALayer {
             ringLayer.startAngle = startAngle
         }
     }
-
+    
     /**
      The end angle for the entire progress ring
      
@@ -395,7 +395,7 @@ fileprivate extension CALayer {
             ringLayer.endAngle = endAngle
         }
     }
-
+    
     /**
      The colors which will be used to create the gradient.
      
@@ -416,7 +416,7 @@ fileprivate extension CALayer {
             ringLayer.gradientColors = gradientColors
         }
     }
-
+    
     /**
      The location for each color provided in `gradientColors`; each location must be
      a CGFloat value in the range of 0 to 1, inclusive. If 0 and 1 are not in the
@@ -441,7 +441,7 @@ fileprivate extension CALayer {
             ringLayer.gradientColorLocations = gradientColorLocations
         }
     }
-
+    
     /**
      The start location for the gradient.
      This property determines where the gradient will begin to draw,
@@ -458,7 +458,7 @@ fileprivate extension CALayer {
             ringLayer.gradientStartPosition = gradientStartPosition
         }
     }
-
+    
     /**
      The end location for the gradient.
      This property determines where the gradient will end drawing,
@@ -475,9 +475,9 @@ fileprivate extension CALayer {
             ringLayer.gradientEndPosition = gradientEndPosition
         }
     }
-
+    
     // MARK: Outer Ring properties
-
+    
     /**
      The width of the outer ring for the progres bar
      
@@ -492,7 +492,7 @@ fileprivate extension CALayer {
             ringLayer.outerRingWidth = outerRingWidth
         }
     }
-
+    
     /**
      The color for the outer ring
      
@@ -507,7 +507,7 @@ fileprivate extension CALayer {
             ringLayer.outerRingColor = outerRingColor
         }
     }
-
+    
     /**
      The color for the outer ring border
      
@@ -522,7 +522,7 @@ fileprivate extension CALayer {
             ringLayer.outerBorderColor = outerBorderColor
         }
     }
-
+    
     /**
      The width for the outer ring border
      
@@ -537,7 +537,7 @@ fileprivate extension CALayer {
             ringLayer.outerBorderWidth = outerBorderWidth
         }
     }
-
+    
     /**
      The style for the outer ring end cap (how it is drawn on screen)
      Range [1,3]
@@ -570,7 +570,7 @@ fileprivate extension CALayer {
             }
         }
     }
-
+    
     /**
      The style for the tip/cap of the outer ring
      
@@ -589,9 +589,9 @@ fileprivate extension CALayer {
             ringLayer.outerCapStyle = outerCapStyle
         }
     }
-
+    
     // MARK: Inner Ring properties
-
+    
     /**
      The width of the inner ring for the progres bar
      
@@ -606,7 +606,7 @@ fileprivate extension CALayer {
             ringLayer.innerRingWidth = innerRingWidth
         }
     }
-
+    
     /**
      The color of the inner ring for the progres bar
      
@@ -621,7 +621,7 @@ fileprivate extension CALayer {
             ringLayer.innerRingColor = innerRingColor
         }
     }
-
+    
     /**
      The spacing between the outer ring and inner ring
      
@@ -638,7 +638,7 @@ fileprivate extension CALayer {
             ringLayer.innerRingSpacing = innerRingSpacing
         }
     }
-
+    
     /**
      The style for the inner ring end cap (how it is drawn on screen)
      
@@ -673,7 +673,7 @@ fileprivate extension CALayer {
             }
         }
     }
-
+    
     /**
      The style for the tip/cap of the inner ring
      
@@ -690,9 +690,9 @@ fileprivate extension CALayer {
             ringLayer.innerCapStyle = innerCapStyle
         }
     }
-
+    
     // MARK: Label
-
+    
     /**
      A toggle for showing or hiding the value label.
      If false the current value will not be shown.
@@ -708,7 +708,7 @@ fileprivate extension CALayer {
             ringLayer.shouldShowValueText = shouldShowValueText
         }
     }
-
+    
     /**
      The text color for the value label field
      
@@ -724,7 +724,7 @@ fileprivate extension CALayer {
             ringLayer.fontColor = fontColor
         }
     }
-
+    
     /**
      The font to be used for the progress indicator.
      All font attributes are specified here except for font color, which is done
@@ -743,7 +743,7 @@ fileprivate extension CALayer {
             ringLayer.font = font
         }
     }
-
+    
     /**
      The name of the value indicator the value label will
      appened to the value
@@ -760,7 +760,7 @@ fileprivate extension CALayer {
             ringLayer.valueIndicator = valueIndicator
         }
     }
-
+    
     /**
      A toggle for either placing the value indicator right or left to the value
      Example: true -> "GB 100" (instead of 100 GB)
@@ -776,7 +776,7 @@ fileprivate extension CALayer {
             ringLayer.rightToLeft = rightToLeft
         }
     }
-
+    
     /**
      A toggle for showing or hiding floating points from
      the value in the value label
@@ -794,7 +794,7 @@ fileprivate extension CALayer {
             ringLayer.showFloatingPoint = showFloatingPoint
         }
     }
-
+    
     /**
      The amount of decimal places to show in the value label
      
@@ -811,9 +811,9 @@ fileprivate extension CALayer {
             ringLayer.decimalPlaces = decimalPlaces
         }
     }
-
+    
     // MARK: Animation properties
-
+    
     /**
      The type of animation function the ring view will use
      
@@ -832,7 +832,7 @@ fileprivate extension CALayer {
             ringLayer.animationStyle = animationStyle
         }
     }
-
+    
     /**
      This returns whether or not the ring is currently animating
      
@@ -845,7 +845,7 @@ fileprivate extension CALayer {
     @objc open var isAnimating: Bool {
         return completionTimer?.isValid ?? false
     }
-
+    
     /**
      The direction the circle is drawn in
      Example: true -> clockwise
@@ -855,24 +855,30 @@ fileprivate extension CALayer {
      
      ## Author
      Pete Walker
-    */
+     */
     @IBInspectable open var isClockwise: Bool = true {
         didSet {
             ringLayer.isClockwise = isClockwise
         }
     }
-
+    
+    // This stores the animation when the timer is paused. We use this variable to continue the animation where it left off. See https://stackoverflow.com/questions/7568567/restoring-animation-where-it-left-off-when-app-resumes-from-background
+    private var animationForKey : CAAnimation?
+    
+    // This variable stores how long remains on the timer when it's paused
+    private var pausedTimeRemaining : TimeInterval = 0
+    
     /// Used to determine when the animation was paused
     private var animationPauseTime: CFTimeInterval?
-
+    
     /// The completion timer, also indicates wether or not the view is animating
     private var completionTimer: Timer?
-
+    
     /// The completion block to call after the animation is done
     private var completion: ProgressCompletion?
-
+    
     // MARK: Layer
-
+    
     /**
      Set the ring layer to the default layer, cated as custom layer
      */
@@ -880,38 +886,38 @@ fileprivate extension CALayer {
         // swiftlint:disable:next force_cast
         return layer as! UICircularProgressRingLayer
     }
-
+    
     /**
      Overrides the default layer with the custom UICircularProgressRingLayer class
      */
     override open class var layerClass: AnyClass {
         return UICircularProgressRingLayer.self
     }
-
+    
     // MARK: Type aliases
-
+    
     /**
      Typealias for the startProgress(:) method closure
      */
     public typealias ProgressCompletion = (() -> Void)
-
+    
     /**
      Typealias for animateProperties(duration:animations:completion:) fucntion completion
      */
     public typealias PropertyAnimationCompletion = (() -> Void)
-
+    
     /**
      Typealias for the value of the ring
      */
     public typealias ProgressValue = CGFloat
-
+    
     /**
      Typealias for the duration of a ring animation
      */
     public typealias ProgressDuration = TimeInterval
-
+    
     // MARK: Methods
-
+    
     /**
      Overriden public init to initialize the layer and view
      */
@@ -920,7 +926,7 @@ fileprivate extension CALayer {
         // Call the internal initializer
         initialize()
     }
-
+    
     /**
      Overriden public init to initialize the layer and view
      */
@@ -929,7 +935,7 @@ fileprivate extension CALayer {
         // Call the internal initializer
         initialize()
     }
-
+    
     /**
      This method initializes the custom CALayer to the default values
      */
@@ -937,20 +943,20 @@ fileprivate extension CALayer {
     private func initialize() {
         // This view will become the value delegate of the layer, which will call the updateValue method when needed
         ringLayer.valueDelegate = self
-
+        
         // Helps with pixelation and blurriness on retina devices
         layer.contentsScale = UIScreen.main.scale
         layer.shouldRasterize = true
         layer.rasterizationScale = UIScreen.main.scale * 2
         layer.masksToBounds = false
-
+        
         ringLayer.fullCircle = fullCircle
         ringLayer.isClockwise = isClockwise
-
+        
         ringLayer.value = value
         ringLayer.maxValue = maxValue
         ringLayer.minValue = minValue
-
+        
         ringLayer.ringStyle = ringStyle
         ringLayer.showsValueKnob = showsValueKnob
         ringLayer.valueKnobSize = valueKnobSize
@@ -963,39 +969,44 @@ fileprivate extension CALayer {
         ringLayer.gradientColorLocations = gradientColorLocations
         ringLayer.gradientStartPosition = gradientStartPosition
         ringLayer.gradientEndPosition = gradientEndPosition
-
+        
         ringLayer.startAngle = startAngle
         ringLayer.endAngle = endAngle
-
+        
         ringLayer.outerRingWidth = outerRingWidth
         ringLayer.outerRingColor = outerRingColor
         ringLayer.outerBorderWidth = outerBorderWidth
         ringLayer.outerBorderColor = outerBorderColor
         ringLayer.outerCapStyle = outerCapStyle
-
+        
         ringLayer.innerRingWidth = innerRingWidth
         ringLayer.innerRingColor = innerRingColor
         ringLayer.innerCapStyle = innerCapStyle
         ringLayer.innerRingSpacing = innerRingSpacing
-
+        
         ringLayer.shouldShowValueText = shouldShowValueText
         ringLayer.valueIndicator = valueIndicator
         ringLayer.fontColor = fontColor
         ringLayer.font = font
         ringLayer.showFloatingPoint = showFloatingPoint
         ringLayer.decimalPlaces = decimalPlaces
-
+        
         backgroundColor = UIColor.clear
         ringLayer.backgroundColor = UIColor.clear.cgColor
+        
+        
+        NotificationCenter.default.addObserver(self, selector:#selector(restoreProgress), name: Notification.Name.UIApplicationWillEnterForeground, object: nil)
+        
+        NotificationCenter.default.addObserver(self, selector:#selector(snapshotProgress), name: Notification.Name.UIApplicationWillResignActive, object: nil)
     }
-
+    
     /**
      Overriden because of custom layer drawing in UICircularProgressRingLayer
      */
     open override func draw(_ rect: CGRect) {
         super.draw(rect)
     }
-
+    
     /**
      Called whenever the layer updates its `value` keypath, this method will then simply call its delegate with
      the `newValue` so that it notifies any delegates who may need to know about value updates in real time
@@ -1003,11 +1014,11 @@ fileprivate extension CALayer {
     internal func didUpdateValue(newValue: ProgressValue) {
         delegate?.didUpdateProgressValue?(for: self, to: newValue)
     }
-
+    
     internal func willDisplayLabel(label: UILabel) {
         delegate?.willDisplayLabel?(for: self, label)
     }
-
+    
     /**
      Sets the current value for the progress ring, calling this method while ring is
      animating will cancel the previously set animation and start a new one.
@@ -1020,7 +1031,7 @@ fileprivate extension CALayer {
      ## Important ##
      Animation duration = 0 will cause no animation to occur, and value will instantly
      be set.
-
+     
      Calling this method again while a current progress animation is in progress will **not**
      cause the animation to be restarted. The old animation will be removed (calling the completion and delegate)
      and a new animation will start from where the old one left off at. If you wish to instead reset an animation
@@ -1035,136 +1046,189 @@ fileprivate extension CALayer {
             self.value = currentValue ?? value
             ringLayer.removeAnimation(forKey: .value)
         }
-
+        
         ringLayer.timeOffset = 0.0
         ringLayer.beginTime = 0.0
         ringLayer.speed = 1.0
         ringLayer.animated = duration > 0
         ringLayer.animationDuration = duration
-
+        
         // Store the completion event locally
         self.completion = completion
-
+        
         // Check if a completion timer is still active and if so stop it
         completionTimer?.invalidate()
         completionTimer = nil
-
+        
         //Create a new completion timer
         completionTimer = Timer.scheduledTimer(timeInterval: duration,
                                                target: self,
                                                selector: #selector(self.animationDidComplete),
                                                userInfo: completion,
                                                repeats: false)
-
+        
         self.value = value
     }
-
+    
     /// Called when the animation timer is complete
     @objc private func animationDidComplete(withTimer timer: Timer) {
         delegate?.didFinishProgress?(for: self)
         (timer.userInfo as? ProgressCompletion)?()
     }
-
+    
+    /**
+     This method is called when the application goes into the background or when the ProgressRing is paused using the pauseProgress method. This is necessary for the animation to properly pick up where it left off. Triggered by UIApplicationWillResignActive.
+     
+     ## Author
+     Nicolai Cornelis
+     */
+    @objc private func snapshotProgress() {
+        
+        // For some reason, if this method is called first by pause and then by resigning into the background, it returns nil the second time. If we just set it to nil without if-let, we won't be able to restore it using restoreProgress() later.
+        if let animation = ringLayer.animation(forKey: .value) {
+            animationForKey = animation
+        }
+        
+    }
+    
+    /**
+     This method is called when the application comes back into the foreground or when the ProgressRing is resumed using the continueProgress method. This is necessary for the animation to properly pick up where it left off. Triggered by UIApplicationWillEnterForeground.
+     
+     ## Author
+     Nicolai Cornelis
+     */
+    @objc private func restoreProgress() {
+        
+        if let animation = animationForKey {
+            ringLayer.add(animation, forKey: AnimationKeys.value.rawValue)
+        }
+        
+    }
+    
     /**
      Pauses the currently running animation and halts all progress.
-
+     
      ## Important ##
-     This method should **only** be called when there is a currently running animation.
-     That is, after a call to `startProgress`.
-
+     This method has no effect unless called when there is a running animation. You should call this method manually whenever the progress ring is not in an active view, for example in viewWillDisappear in a parent view controller.
+     
      ## Author
-     Luis Padron
+     Luis Padron & Nicolai Cornelis
      */
     @objc open func pauseProgress() {
         guard isAnimating else {
-            fatalError("\(#file):\(#line) Attempt to pause progress with no currently running animation")
+            #if DEBUG
+            print("UICircularProgressRing: Progress was paused without having been started. This has no effect but may indicate that you're unnecessarily calling this method.")
+            #endif
+            return
         }
-
+        
+        #if DEBUG
+        print("UICircularProgressRing: Paused")
+        #endif
+        
+        self.snapshotProgress()
+        
         let pauseTime = ringLayer.convertTime(CACurrentMediaTime(), from: nil)
         animationPauseTime = pauseTime
-        ringLayer.timeOffset = pauseTime
-
+        
         ringLayer.speed = 0.0
-
+        ringLayer.timeOffset = pauseTime
+        
+        if let fireTime = completionTimer?.fireDate {
+            pausedTimeRemaining = fireTime.timeIntervalSince(Date())
+        } else {
+            pausedTimeRemaining = 0
+        }
+        
         //Cancel the timer, it will have to be re-created when we continue the progress
         completionTimer?.invalidate()
         completionTimer = nil
-
+        
         delegate?.didPauseProgress?(for: self)
     }
-
+    
     /**
-     Continues the animation with it's remaining time from where it left off before it was paused.
-
-     ## Important ##
-     This method should **only** be called when there is a currently paused animation.
-     That is, only call this method after you have called `pauseProgress`.
-
+     Continues the animation with its remaining time from where it left off before it was paused. This method has no effect unless called when there is a paused animation. You should call this method when you wish to resume a paused animation.
+     
      ## Author
-     Luis Padron
+     Luis Padron & Nicolai Cornelis
      */
     @objc open func continueProgress() {
         guard let pauseTime = animationPauseTime else {
-            fatalError("\(#file):\(#line) Attempt to continue progress on a ring that was never paused")
+            #if DEBUG
+            print("UICircularProgressRing: Progress was continued without having been paused. This has no effect but may indicate that you're unnecessarily calling this method.")
+            #endif
+            return
         }
-
-        ringLayer.timeOffset = 0.0
+        
+        #if DEBUG
+        print("UICircularProgressRing: Resumed")
+        #endif
+        
+        self.restoreProgress()
+        
         ringLayer.speed = 1.0
-        ringLayer.beginTime = 0.0
-
-        let currentTime = ringLayer.convertTime(CACurrentMediaTime(), from: nil)
-        ringLayer.beginTime = currentTime - pauseTime
-
-        //Create a new completion timer
-        completionTimer = Timer.scheduledTimer(timeInterval: currentTime - pauseTime,
+        ringLayer.timeOffset = 0.0
+        ringLayer.beginTime = 0.0;
+        
+        let timeSincePause = ringLayer.convertTime(CACurrentMediaTime(), from: nil) - pauseTime
+        
+        ringLayer.beginTime = timeSincePause
+        
+        // Create a new completion timer with the time left when the timer was paused
+        completionTimer = Timer.scheduledTimer(timeInterval: pausedTimeRemaining,
                                                target: self,
                                                selector: #selector(animationDidComplete),
                                                userInfo: completion,
                                                repeats: false)
-
+        
         animationPauseTime = nil
-
+        
         delegate?.didContinueProgress?(for: self)
     }
-
+    
     /**
      Resets the progress back to the `minValue` of the progress ring.
      Does **not** perform any animations
-
+     
      ## Author
      Luis Padron
      */
     @objc open func resetProgress() {
         ringLayer.animated = false
         ringLayer.removeAnimation(forKey: .value)
+        animationForKey = nil;
         value = minValue
-
+        
         // Stop the timer and thus make the completion method not get fired
         completionTimer?.invalidate()
         completionTimer = nil
         animationPauseTime = nil
+        
+        // Remove reference to the completion block
+        completion = nil;
     }
-
+    
     /**
      This function allows animation of the animatable properties of the `UICircularProgressRing`.
      These properties include `innerRingColor, innerRingWidth, outerRingColor, outerRingWidth, innerRingSpacing, fontColor`.
-
+     
      Simply call this function and inside of the animation block change the animatable properties as you would in any `UView`
      animation block.
-
+     
      The completion block is called when all animations finish.
      */
     @objc open func animateProperties(duration: TimeInterval, animations: () -> Void) {
         animateProperties(duration: duration, animations: animations, completion: nil)
     }
-
+    
     /**
      This function allows animation of the animatable properties of the `UICircularProgressRing`.
      These properties include `innerRingColor, innerRingWidth, outerRingColor, outerRingWidth, innerRingSpacing, fontColor`.
-
+     
      Simply call this function and inside of the animation block change the animatable properties as you would in any `UView`
      animation block.
-
+     
      The completion block is called when all animations finish.
      */
     @objc open func animateProperties(duration: TimeInterval, animations: () -> Void,


### PR DESCRIPTION
Hello

As requested. I did a loooot of testing back and forth, and I ended up separating pause/continue from backgrounding, since there is probably many cases where backgrounding should not stop the timer.

The progress ring now listens for notifications from AppDelgate to be able to save and restore the animation when moving in and out of backgrounding.

I *think* everything works as you would expect now. The only problem I see now is that if you don't pause the timer and you move it out of the view (present a VC on top of it), the animation will stop just like before. I added to the docs that you should call pause in viewWillDisappear to be able to pause and restore it in this case. This of course means that it doesn't really work if you want it to keep counting even when another VC is on top of it. I have no use-case for that so I'm satisfied with how it is now.

I suggest you test it yourself before you merge it.

I also removed the crash when calling continue or pause if not paused or started. Now it just logs but only when compiled for debug.

Updated comments in code to reflect these changes.