### PR TITLE
Fixing issue with setting value above maxValue

### DIFF
--- a/src/UICircularProgressRing/UICircularProgressRing.swift
+++ b/src/UICircularProgressRing/UICircularProgressRing.swift
@@ -133,6 +133,9 @@ fileprivate extension CALayer {
                 print("Attempted to set a value less than minValue, value has been set to minValue.\n")
                 value = minValue
             }
+            if value > maxValue {
+                value = maxValue
+            }
             ringLayer.value = value
         }
     }

--- a/src/UICircularProgressRing/UICircularProgressRing.swift
+++ b/src/UICircularProgressRing/UICircularProgressRing.swift
@@ -129,11 +129,17 @@ fileprivate extension CALayer {
     @IBInspectable open var value: ProgressValue = 0 {
         didSet {
             if value < minValue {
-                print("Warning in: \(#file):\(#line)")
-                print("Attempted to set a value less than minValue, value has been set to minValue.\n")
+                #if DEBUG
+                    print("Warning in: \(#file):\(#line)")
+                    print("Attempted to set a value less than minValue, value has been set to minValue.\n")
+                #endif
                 value = minValue
             }
             if value > maxValue {
+                #if DEBUG
+                    print("Warning in: \(#file):\(#line)")
+                    print("Attempted to set a value greater than maxValue, value has been set to maxValue.\n")
+                #endif
                 value = maxValue
             }
             ringLayer.value = value


### PR DESCRIPTION
I was observing a similar problem with maxValue to what was already solved in the code for minValue - if the value was over the maxValue it would allow it and the progress would render outside of the expected bounds.

This was apparent when using with .fullCircle = false. But I'm guessing for fullCircle true it would also cause an animation delay for a fullCircle = true scenario as well if you went over the maxValue by enough even if it was invisible.