### PR TITLE
 Fix issue #133 by improving the drawing of border to work for fullCircle true & false.

### DIFF
--- a/src/UICircularProgressRing/UICircularProgressRing.swift
+++ b/src/UICircularProgressRing/UICircularProgressRing.swift
@@ -257,6 +257,9 @@ fileprivate extension CALayer {
     @objc open var ringStyle: UICircularProgressRingStyle = .inside {
         didSet {
             ringLayer.ringStyle = ringStyle
+            if ringStyle != .bordered {
+                outerBorderWidth = 0
+            }
         }
     }
 

--- a/src/UICircularProgressRing/UICircularProgressRingLayer.swift
+++ b/src/UICircularProgressRing/UICircularProgressRingLayer.swift
@@ -322,7 +322,6 @@ class UICircularProgressRingLayer: CAShapeLayer {
             borderPath.lineCapStyle = outerCapStyle
             outerBorderColor.setStroke()
             borderPath.stroke()
-            
         default:
             break
         }

--- a/src/UICircularProgressRing/UICircularProgressRingLayer.swift
+++ b/src/UICircularProgressRing/UICircularProgressRingLayer.swift
@@ -211,27 +211,21 @@ class UICircularProgressRingLayer: CAShapeLayer {
      */
     private func drawOuterRing() {
         guard outerRingWidth > 0 else { return }
-
-        
-        if (ringStyle != .bordered) {
+        if ringStyle != .bordered {
             outerBorderWidth = 0
         }
-        
         let center: CGPoint = CGPoint(x: bounds.midX, y: bounds.midY)
         let offSet = max(outerRingWidth, innerRingWidth) / 2 + (showsValueKnob ? valueKnobSize / 4 : 0) + (outerBorderWidth*2)
         let outerRadius: CGFloat = min(bounds.width, bounds.height) / 2 - offSet
         let start: CGFloat = fullCircle ? 0 : startAngle.toRads
         let end: CGFloat = fullCircle ? .pi * 2 : endAngle.toRads
-
         let outerPath = UIBezierPath(arcCenter: center,
                                      radius: outerRadius,
                                      startAngle: start,
                                      endAngle: end,
                                      clockwise: true)
-
         outerPath.lineWidth = outerRingWidth
         outerPath.lineCapStyle = outerCapStyle
-
         // Update path depending on style of the ring
         updateOuterRingPath(outerPath, radius: outerRadius, style: ringStyle)
 
@@ -310,7 +304,6 @@ class UICircularProgressRingLayer: CAShapeLayer {
             path.lineCapStyle = .round
 
         case .bordered:
-
             let center: CGPoint = CGPoint(x: bounds.midX, y: bounds.midY)
             let offSet = max(outerRingWidth, innerRingWidth) / 2 + (showsValueKnob ? valueKnobSize / 4 : 0) + (outerBorderWidth*2)
             let outerRadius: CGFloat = min(bounds.width, bounds.height) / 2 - offSet
@@ -318,7 +311,6 @@ class UICircularProgressRingLayer: CAShapeLayer {
             let borderEndAngle = outerCapStyle == .butt ? endAngle+outerBorderWidth : endAngle
             let start: CGFloat = fullCircle ? 0 : borderStartAngle.toRads
             let end: CGFloat = fullCircle ? .pi * 2 : borderEndAngle.toRads
-            
             let borderPath = UIBezierPath(arcCenter: center,
                                           radius: outerRadius,
                                           startAngle: start,
@@ -330,6 +322,7 @@ class UICircularProgressRingLayer: CAShapeLayer {
             borderPath.lineCapStyle = outerCapStyle
             outerBorderColor.setStroke()
             borderPath.stroke()
+            
         default:
             break
         }

--- a/src/UICircularProgressRing/UICircularProgressRingLayer.swift
+++ b/src/UICircularProgressRing/UICircularProgressRingLayer.swift
@@ -211,9 +211,6 @@ class UICircularProgressRingLayer: CAShapeLayer {
      */
     private func drawOuterRing() {
         guard outerRingWidth > 0 else { return }
-        if ringStyle != .bordered {
-            outerBorderWidth = 0
-        }
         let center: CGPoint = CGPoint(x: bounds.midX, y: bounds.midY)
         let offSet = max(outerRingWidth, innerRingWidth) / 2 + (showsValueKnob ? valueKnobSize / 4 : 0) + (outerBorderWidth*2)
         let outerRadius: CGFloat = min(bounds.width, bounds.height) / 2 - offSet

--- a/src/UICircularProgressRing/UICircularProgressRingLayer.swift
+++ b/src/UICircularProgressRing/UICircularProgressRingLayer.swift
@@ -212,8 +212,13 @@ class UICircularProgressRingLayer: CAShapeLayer {
     private func drawOuterRing() {
         guard outerRingWidth > 0 else { return }
 
+        
+        if (ringStyle != .bordered) {
+            outerBorderWidth = 0
+        }
+        
         let center: CGPoint = CGPoint(x: bounds.midX, y: bounds.midY)
-        let offSet = max(outerRingWidth, innerRingWidth) / 2 + (showsValueKnob ? valueKnobSize / 4 : 0)
+        let offSet = max(outerRingWidth, innerRingWidth) / 2 + (showsValueKnob ? valueKnobSize / 4 : 0) + (outerBorderWidth*2)
         let outerRadius: CGFloat = min(bounds.width, bounds.height) / 2 - offSet
         let start: CGFloat = fullCircle ? 0 : startAngle.toRads
         let end: CGFloat = fullCircle ? .pi * 2 : endAngle.toRads
@@ -305,26 +310,26 @@ class UICircularProgressRingLayer: CAShapeLayer {
             path.lineCapStyle = .round
 
         case .bordered:
-            let innerBorder = CAShapeLayer()
-            addSublayer(innerBorder)
 
-            let roundedRect1 = path.bounds.insetBy(dx: outerRingWidth / 2, dy: outerRingWidth / 2)
-            let path1 = UIBezierPath(roundedRect: roundedRect1, cornerRadius: radius)
-            innerBorder.path = path1.cgPath
-            innerBorder.fillColor = UIColor.clear.cgColor
-            innerBorder.strokeColor = outerBorderColor.cgColor
-            innerBorder.lineWidth = outerBorderWidth
-
-            let outerBorder = CAShapeLayer()
-            addSublayer(outerBorder)
-
-            let roundedRect2 = path.bounds.insetBy(dx: -outerRingWidth / 2, dy: -outerRingWidth / 2)
-            let path2 = UIBezierPath(roundedRect: roundedRect2, cornerRadius: radius)
-            outerBorder.path = path2.cgPath
-            outerBorder.fillColor = UIColor.clear.cgColor
-            outerBorder.strokeColor = outerBorderColor.cgColor
-            outerBorder.lineWidth = outerBorderWidth
-
+            let center: CGPoint = CGPoint(x: bounds.midX, y: bounds.midY)
+            let offSet = max(outerRingWidth, innerRingWidth) / 2 + (showsValueKnob ? valueKnobSize / 4 : 0) + (outerBorderWidth*2)
+            let outerRadius: CGFloat = min(bounds.width, bounds.height) / 2 - offSet
+            let borderStartAngle = outerCapStyle == .butt ? startAngle-outerBorderWidth : startAngle
+            let borderEndAngle = outerCapStyle == .butt ? endAngle+outerBorderWidth : endAngle
+            let start: CGFloat = fullCircle ? 0 : borderStartAngle.toRads
+            let end: CGFloat = fullCircle ? .pi * 2 : borderEndAngle.toRads
+            
+            let borderPath = UIBezierPath(arcCenter: center,
+                                          radius: outerRadius,
+                                          startAngle: start,
+                                          endAngle: end,
+                                          clockwise: true)
+            UIColor.clear.setFill()
+            borderPath.fill()
+            borderPath.lineWidth = (outerBorderWidth*2) + outerRingWidth
+            borderPath.lineCapStyle = outerCapStyle
+            outerBorderColor.setStroke()
+            borderPath.stroke()
         default:
             break
         }
@@ -366,6 +371,9 @@ class UICircularProgressRingLayer: CAShapeLayer {
             let difference = outerRingWidth * 2 + innerRingSpacing + (showsValueKnob ? valueKnobSize / 2 : 0)
             let offSet = innerRingWidth / 2 + (showsValueKnob ? valueKnobSize / 2 : 0)
             radiusIn = (min(bounds.width - difference, bounds.height - difference) / 2) - offSet
+        case .bordered:
+            let offSet = (max(outerRingWidth, innerRingWidth) / 2) + (showsValueKnob ? valueKnobSize / 4 : 0) + (outerBorderWidth*2)
+            radiusIn = (min(bounds.width, bounds.height) / 2) - offSet
         default:
             let offSet = (max(outerRingWidth, innerRingWidth) / 2) + (showsValueKnob ? valueKnobSize / 4 : 0)
             radiusIn = (min(bounds.width, bounds.height) / 2) - offSet


### PR DESCRIPTION
The new ringStyle `.bordered` was added by me. I saw it only fitting that I fix issue #133 😄
Issue #133 does not have any screenshots, but after testing it, I found out that the result is something like this:

![image](https://user-images.githubusercontent.com/29616360/46257840-b2adb800-c4c9-11e8-9c97-8ce13495335b.png)

The problem is the border path I was drawing used the `UIBezierPath(roundedRect:cornerRadius:)` initializer. This ensures that the border is always a fully rounded rectangular (or in the fullCircle case, a circle!).             
This was perfect for my use case which only required a full circle.

BUT, because the library is dynamic and allows drawing partial circles (I missed that!), the borders needed to be drawn in a different way. With this pull request, the result is always perfect for `.bordered` ringStyle:

`fullCircle = true`
![image](https://user-images.githubusercontent.com/29616360/46257760-9c066180-c4c7-11e8-9e6b-d8be26e10389.png)

`fullCircle = false` and `lineCapStyle = .round`
![image](https://user-images.githubusercontent.com/29616360/46257742-4df15e00-c4c7-11e8-8bd8-d03d36237e18.png)

`fullCircle = false` and `lineCapStyle = .square`
![image](https://user-images.githubusercontent.com/29616360/46257718-01a61e00-c4c7-11e8-8def-5af4c66c46f2.png)

`fullCircle = false` and `lineCapStyle = .butt`
![image](https://user-images.githubusercontent.com/29616360/46257697-c1df3680-c4c6-11e8-9506-34098100fa42.png)
