### PR TITLE
Podspec update to allow for tvOS deployment

### DIFF
--- a/UICircularProgressRing.podspec
+++ b/UICircularProgressRing.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   s.social_media_url   = "https://luispadron.com"
 
   s.ios.deployment_target = "8.0"
+  s.tvos.deployment_target = "10.0"
   s.source       = { :git => "https://github.com/luispadron/UICircularProgressRing.git", :tag => "v#{s.version}" }
 
   s.source_files  = "src/UICircularProgressRing", "src/UICircularProgressRing/**/*.{h,m}"


### PR DESCRIPTION
I was unable to use the library in my tvOS project due to it being marked as iOS-only. This PR is just to add tvOS to the podspec. In my experience no other changes were required in the actual code for it to work properly.