### PR TITLE
UICircularTimerRing valueFormatter type updated.

### DIFF
--- a/src/UICircularProgressRing/UICircularTimerRing.swift
+++ b/src/UICircularProgressRing/UICircularTimerRing.swift
@@ -33,7 +33,7 @@ final public class UICircularTimerRing: UICircularRing {
 
      Default formatter is of type `UICircularTimerRingFormatter`.
      */
-    public var valueFormatter = UICircularTimerRingFormatter() {
+    public var valueFormatter: UICircularRingValueFormatter = UICircularTimerRingFormatter() {
         didSet { ringLayer.valueFormatter = valueFormatter }
     }
 


### PR DESCRIPTION
added type to valueFormatter to fix bug when trying to subclass UICircularRingValueFormatter.

Without this, the compiler complains with "Cannot assign value of type (custom subclass here) to type 'UICircularTimerRingFormatter'", therefore setting the formatter to a custom subclass is not possible.

issue created: https://github.com/luispadron/UICircularProgressRing/issues/169