### PR TITLE
Add borderWidth to outer radius when having 'bordered' style

### DIFF
--- a/src/UICircularProgressRing/UICircularRingLayer.swift
+++ b/src/UICircularProgressRing/UICircularRingLayer.swift
@@ -178,7 +178,7 @@ class UICircularRingLayer: CAShapeLayer {
         let start: CGFloat = ring.fullCircle ? 0 : ring.startAngle.rads
         let end: CGFloat = ring.fullCircle ? .pi * 2 : ring.endAngle.rads
         let outerPath = UIBezierPath(arcCenter: center,
-                                     radius: outerRadius,
+                                     radius: outerRadius + borderWidth,
                                      startAngle: start,
                                      endAngle: end,
                                      clockwise: true)
@@ -275,7 +275,7 @@ class UICircularRingLayer: CAShapeLayer {
             let start: CGFloat = ring.fullCircle ? 0 : borderStartAngle.rads
             let end: CGFloat = ring.fullCircle ? .pi * 2 : borderEndAngle.rads
             let borderPath = UIBezierPath(arcCenter: center,
-                                          radius: outerRadius,
+                                          radius: outerRadius + borderWidth,
                                           startAngle: start,
                                           endAngle: end,
                                           clockwise: true)
@@ -330,7 +330,7 @@ class UICircularRingLayer: CAShapeLayer {
             radiusIn = (min(bounds.width - difference, bounds.height - difference) / 2) - offSet
         case .bordered(let borderWidth, _):
             let offSet = (max(ring.outerRingWidth, ring.innerRingWidth) / 2) + (knobSize / 4) + (borderWidth * 2)
-            radiusIn = (min(bounds.width, bounds.height) / 2) - offSet
+            radiusIn = (min(bounds.width, bounds.height) / 2) - offSet + borderWidth
         default:
             let offSet = (max(ring.outerRingWidth, ring.innerRingWidth) / 2) + (knobSize / 4)
             radiusIn = (min(bounds.width, bounds.height) / 2) - offSet


### PR DESCRIPTION
Prevent outer circle border to be drawn with additional empty space border.
This fix allows to draw border right within bounds without additional space in between of bounds and circle border.

UI setup:
```.style = .bordered(width: 5, color: <#Color#>)
.innerRingWidth = 2
.outerRingWidth = 2
.outerRingColor = <#Color#>
.startAngle = 270
.value = 99
```

UI Before Fix:
<img width="57" alt="Screenshot 2019-07-14 at 22 11 11" src="https://user-images.githubusercontent.com/1472675/61188786-87750d80-a684-11e9-8051-067993cc09c9.png">

UI After FIx:
<img width="58" alt="Screenshot 2019-07-14 at 22 10 06" src="https://user-images.githubusercontent.com/1472675/61188784-7cba7880-a684-11e9-8d79-02c2ded15b01.png">
