### PR TITLE
Add support for custom knob paths, and knob images

### DIFF
--- a/UICircularProgressRing.podspec
+++ b/UICircularProgressRing.podspec
@@ -2,7 +2,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "UICircularProgressRing"
-  s.version      = "6.1.1"
+  s.version      = "6.2.1"
   s.summary      = "A highly customizable circular progress bar for iOS written in Swift"
 
   s.description  = <<-DESC

--- a/src/UICircularProgressRing/UICircularRing.swift
+++ b/src/UICircularProgressRing/UICircularRing.swift
@@ -112,6 +112,20 @@ import UIKit
     }
 
     /**
+     A toggle for showing or hiding the value knob when current value == minimum value.
+     If false the value knob will not be shown when current value == minimum value.
+
+     ## Important ##
+     Default = false
+
+     ## Author
+     Tom Knapen
+     */
+    @IBInspectable public var shouldDrawMinValueKnob: Bool = false {
+        didSet { ringLayer.setNeedsDisplay() }
+    }
+
+    /**
      Style for the value knob, default is `nil`.
 
      ## Important ##

--- a/src/UICircularProgressRing/UICircularRing.swift
+++ b/src/UICircularProgressRing/UICircularRing.swift
@@ -26,7 +26,7 @@
 import UIKit
 
 /**
- 
+
  # UICircularRing
 
  This is the base class of `UICircularProgressRing` and `UICircularTimerRing`.
@@ -35,13 +35,13 @@ import UIKit
 
  This is the UIView subclass that creates and handles everything
  to do with the circular ring.
- 
+
  This class has a custom CAShapeLayer (`UICircularRingLayer`) which
  handels the drawing and animating of the view
- 
+
  ## Author
  Luis Padron
- 
+
  */
 @IBDesignable open class UICircularRing: UIView {
 
@@ -49,18 +49,18 @@ import UIKit
 
     /**
      Whether or not the progress ring should be a full circle.
-     
+
      What this means is that the outer ring will always go from 0 - 360 degrees and
      the inner ring will be calculated accordingly depending on current value.
-     
+
      ## Important ##
      Default = true
-     
+
      When this property is true any value set for `endAngle` will be ignored.
-     
+
      ## Author
      Luis Padron
-     
+
      */
     @IBInspectable open var fullCircle: Bool = true {
         didSet { ringLayer.setNeedsDisplay() }
@@ -70,14 +70,14 @@ import UIKit
 
     /**
      The style of the progress ring.
-     
+
      Type: `UICircularRingStyle`
-     
+
      The five styles include `inside`, `ontop`, `dashed`, `dotted`, and `gradient`
-     
+
      ## Important ##
      Default = UICircularRingStyle.inside
-     
+
      ## Author
      Luis Padron
      */
@@ -138,15 +138,15 @@ import UIKit
 
     /**
      The start angle for the entire progress ring view.
-     
+
      Please note that Cocoa Touch uses a clockwise rotating unit circle.
      I.e: 90 degrees is at the bottom and 270 degrees is at the top
-     
+
      ## Important ##
      Default = 0 (degrees)
-     
+
      Values should be in degrees (they're converted to radians internally)
-     
+
      ## Author
      Luis Padron
      */
@@ -156,15 +156,15 @@ import UIKit
 
     /**
      The end angle for the entire progress ring
-     
+
      Please note that Cocoa Touch uses a clockwise rotating unit circle.
      I.e: 90 degrees is at the bottom and 270 degrees is at the top
-     
+
      ## Important ##
      Default = 360 (degrees)
-     
+
      Values should be in degrees (they're converted to radians internally)
-     
+
      ## Author
      Luis Padron
      */
@@ -176,10 +176,10 @@ import UIKit
 
     /**
      The width of the outer ring for the progres bar
-     
+
      ## Important ##
      Default = 10.0
-     
+
      ## Author
      Luis Padron
      */
@@ -189,10 +189,10 @@ import UIKit
 
     /**
      The color for the outer ring
-     
+
      ## Important ##
      Default = UIColor.gray
-     
+
      ## Author
      Luis Padron
      */
@@ -202,14 +202,14 @@ import UIKit
 
     /**
      The style for the tip/cap of the outer ring
-     
+
      Type: `CGLineCap`
-     
+
      ## Important ##
      Default = CGLineCap.butt
-     
+
      This is only noticible when ring is not a full circle.
-     
+
      ## Author
      Luis Padron
      */
@@ -221,10 +221,10 @@ import UIKit
 
     /**
      The width of the inner ring for the progres bar
-     
+
      ## Important ##
      Default = 5.0
-     
+
      ## Author
      Luis Padron
      */
@@ -234,10 +234,10 @@ import UIKit
 
     /**
      The color of the inner ring for the progres bar
-     
+
      ## Important ##
      Default = UIColor.blue
-     
+
      ## Author
      Luis Padron
      */
@@ -247,12 +247,12 @@ import UIKit
 
     /**
      The spacing between the outer ring and inner ring
-     
+
      ## Important ##
      This only applies when using progressRingStyle = 1
-     
+
      Default = 1
-     
+
      ## Author
      Luis Padron
      */
@@ -262,12 +262,12 @@ import UIKit
 
     /**
      The style for the tip/cap of the inner ring
-     
+
      Type: `CGLineCap`
-     
+
      ## Important ##
      Default = CGLineCap.round
-     
+
      ## Author
      Luis Padron
      */
@@ -279,11 +279,11 @@ import UIKit
 
     /**
      The text color for the value label field
-     
+
      ## Important ##
      Default = UIColor.black
-     
-     
+
+
      ## Author
      Luis Padron
      */
@@ -295,12 +295,12 @@ import UIKit
      The font to be used for the progress indicator.
      All font attributes are specified here except for font color, which is done
      using `fontColor`.
-     
-     
+
+
      ## Important ##
      Default = UIFont.systemFont(ofSize: 18)
-     
-     
+
+
      ## Author
      Luis Padron
      */
@@ -310,10 +310,10 @@ import UIKit
 
     /**
      This returns whether or not the ring is currently animating
-     
+
      ## Important ##
      Get only property
-     
+
      ## Author
      Luis Padron
      */
@@ -324,10 +324,10 @@ import UIKit
     /**
      The direction the circle is drawn in
      Example: true -> clockwise
-     
+
      ## Important ##
      Default = true (draw the circle clockwise)
-     
+
      ## Author
      Pete Walker
      */
@@ -541,10 +541,10 @@ import UIKit
     /**
      This function allows animation of the animatable properties of the `UICircularRing`.
      These properties include `innerRingColor, innerRingWidth, outerRingColor, outerRingWidth, innerRingSpacing, fontColor`.
-     
+
      Simply call this function and inside of the animation block change the animatable properties as you would in any `UView`
      animation block.
-     
+
      The completion block is called when all animations finish.
      */
     open func animateProperties(duration: TimeInterval, animations: () -> Void) {
@@ -554,10 +554,10 @@ import UIKit
     /**
      This function allows animation of the animatable properties of the `UICircularRing`.
      These properties include `innerRingColor, innerRingWidth, outerRingColor, outerRingWidth, innerRingSpacing, fontColor`.
-     
+
      Simply call this function and inside of the animation block change the animatable properties as you would in any `UView`
      animation block.
-     
+
      The completion block is called when all animations finish.
      */
     open func animateProperties(duration: TimeInterval, animations: () -> Void,

--- a/src/UICircularProgressRing/UICircularRingLayer.swift
+++ b/src/UICircularProgressRing/UICircularRingLayer.swift
@@ -374,6 +374,20 @@ class UICircularRingLayer: CAShapeLayer {
         context.drawPath(using: .fill)
 
         context.restoreGState()
+
+        if let image = knobStyle.image {
+            context.saveGState()
+
+            let imageRect = rect.inset(by: knobStyle.imageInsets)
+            if let tintColor = knobStyle.imageTintColor {
+                tintColor.setFill()
+                image.withRenderingMode(.alwaysTemplate).draw(in: imageRect)
+            } else {
+                image.draw(in: imageRect)
+            }
+
+            context.restoreGState()
+        }
     }
 
     /**

--- a/src/UICircularProgressRing/UICircularRingLayer.swift
+++ b/src/UICircularProgressRing/UICircularRingLayer.swift
@@ -265,10 +265,11 @@ class UICircularRingLayer: CAShapeLayer {
 
         case .bordered(let borderWidth, let borderColor):
             let center: CGPoint = CGPoint(x: bounds.midX, y: bounds.midY)
-            let knobSize = valueKnobStyle?.size ?? 0
-            let offSet = max(ring.outerRingWidth, ring.innerRingWidth) / 2
-                            + knobSize / 4
-                            + borderWidth * 2
+            let offSet: CGFloat = {
+                let offset = max(ring.outerRingWidth, ring.innerRingWidth) / 2
+                let size = valueKnobStyle?.size ?? 0
+                return offset + (size / 4) + (borderWidth * 2)
+            }()
             let outerRadius: CGFloat = min(bounds.width, bounds.height) / 2 - offSet
             let borderStartAngle = ring.outerCapStyle == .butt ? ring.startAngle - borderWidth : ring.startAngle
             let borderEndAngle = ring.outerCapStyle == .butt ? ring.endAngle + borderWidth : ring.endAngle

--- a/src/UICircularProgressRing/UICircularRingLayer.swift
+++ b/src/UICircularProgressRing/UICircularRingLayer.swift
@@ -363,7 +363,7 @@ class UICircularRingLayer: CAShapeLayer {
         context.saveGState()
 
         let rect = CGRect(origin: origin, size: CGSize(width: knobStyle.size, height: knobStyle.size))
-        let knobPath = UIBezierPath(ovalIn: rect)
+        let knobPath = knobStyle.path.from(rect)
 
         context.setShadow(offset: knobStyle.shadowOffset,
                           blur: knobStyle.shadowBlur,

--- a/src/UICircularProgressRing/UICircularRingLayer.swift
+++ b/src/UICircularProgressRing/UICircularRingLayer.swift
@@ -246,7 +246,7 @@ class UICircularRingLayer: CAShapeLayer {
             ctx.restoreGState()
         }
 
-        if let knobStyle = ring.valueKnobStyle, value > minValue {
+        if let knobStyle = ring.valueKnobStyle, ((value > minValue) || (ring?.shouldDrawMinValueKnob ?? false)) {
             let knobOffset = knobStyle.size / 2
             drawValueKnob(in: ctx, origin: CGPoint(x: innerPath.currentPoint.x - knobOffset,
                                                    y: innerPath.currentPoint.y - knobOffset))

--- a/src/UICircularProgressRing/UICircularRingStyle.swift
+++ b/src/UICircularProgressRing/UICircularRingStyle.swift
@@ -54,6 +54,16 @@ public enum UICircularRingStyle {
     case bordered(width: CGFloat, color: UIColor)
 }
 
+public struct UICircularRingValueKnobPath {
+	let from: (CGRect) -> UIBezierPath
+
+	public init(_ from: @escaping (CGRect) -> UIBezierPath) {
+		self.from = from
+	}
+
+	public static let oval: UICircularRingValueKnobPath = .init { UIBezierPath(ovalIn: $0) }
+}
+
 // MARK: UICircularRingValueKnobStyle
 
 /**
@@ -77,6 +87,9 @@ public struct UICircularRingValueKnobStyle {
     /// the color of the knob
     public let color: UIColor
 
+	/// the path of the knob
+	public let path: UICircularRingValueKnobPath
+
     /// the amount of blur to give the shadow
     public let shadowBlur: CGFloat
 
@@ -98,6 +111,7 @@ public struct UICircularRingValueKnobStyle {
     /// creates a new `UICircularRingValueKnobStyle`
     public init(size: CGFloat,
                 color: UIColor,
+				path: UICircularRingValueKnobPath = .oval,
                 shadowBlur: CGFloat = 2.0,
                 shadowOffset: CGSize = .zero,
                 shadowColor: UIColor = UIColor.black.withAlphaComponent(0.8),
@@ -106,6 +120,7 @@ public struct UICircularRingValueKnobStyle {
                 imageInsets: UIEdgeInsets = .zero) {
         self.size = size
         self.color = color
+		self.path = path
         self.shadowBlur = shadowBlur
         self.shadowOffset = shadowOffset
         self.shadowColor = shadowColor

--- a/src/UICircularProgressRing/UICircularRingStyle.swift
+++ b/src/UICircularProgressRing/UICircularRingStyle.swift
@@ -55,13 +55,13 @@ public enum UICircularRingStyle {
 }
 
 public struct UICircularRingValueKnobPath {
-	let from: (CGRect) -> UIBezierPath
+    let from: (CGRect) -> UIBezierPath
 
-	public init(_ from: @escaping (CGRect) -> UIBezierPath) {
-		self.from = from
-	}
+    public init(_ from: @escaping (CGRect) -> UIBezierPath) {
+        self.from = from
+    }
 
-	public static let oval: UICircularRingValueKnobPath = .init { UIBezierPath(ovalIn: $0) }
+    public static let oval: UICircularRingValueKnobPath = .init { UIBezierPath(ovalIn: $0) }
 }
 
 // MARK: UICircularRingValueKnobStyle
@@ -87,8 +87,8 @@ public struct UICircularRingValueKnobStyle {
     /// the color of the knob
     public let color: UIColor
 
-	/// the path of the knob
-	public let path: UICircularRingValueKnobPath
+    /// the path of the knob
+    public let path: UICircularRingValueKnobPath
 
     /// the amount of blur to give the shadow
     public let shadowBlur: CGFloat
@@ -111,7 +111,7 @@ public struct UICircularRingValueKnobStyle {
     /// creates a new `UICircularRingValueKnobStyle`
     public init(size: CGFloat,
                 color: UIColor,
-				path: UICircularRingValueKnobPath = .oval,
+                path: UICircularRingValueKnobPath = .oval,
                 shadowBlur: CGFloat = 2.0,
                 shadowOffset: CGSize = .zero,
                 shadowColor: UIColor = UIColor.black.withAlphaComponent(0.8),
@@ -120,7 +120,7 @@ public struct UICircularRingValueKnobStyle {
                 imageInsets: UIEdgeInsets = .zero) {
         self.size = size
         self.color = color
-		self.path = path
+        self.path = path
         self.shadowBlur = shadowBlur
         self.shadowOffset = shadowOffset
         self.shadowColor = shadowColor

--- a/src/UICircularProgressRing/UICircularRingStyle.swift
+++ b/src/UICircularProgressRing/UICircularRingStyle.swift
@@ -28,14 +28,14 @@ import UIKit.UIColor
 // MARK: UICircularRingStyle
 
 /**
- 
+
  # UICircularRingStyle
- 
+
  This is an enumeration which is used to determine the style of the progress ring.
- 
+
  ## Author
  Luis Padron
- 
+
  */
 public enum UICircularRingStyle {
     /// inner ring is inside the circle
@@ -86,17 +86,32 @@ public struct UICircularRingValueKnobStyle {
     /// the color for the shadow
     public let shadowColor: UIColor
 
+    // the image of the knob
+    public let image: UIImage?
+
+    // the tint color of the knob image
+    public let imageTintColor: UIColor?
+
+    // the inset of the thumb image
+    public let imageInsets: UIEdgeInsets
+
     /// creates a new `UICircularRingValueKnobStyle`
     public init(size: CGFloat,
                 color: UIColor,
                 shadowBlur: CGFloat = 2.0,
                 shadowOffset: CGSize = .zero,
-                shadowColor: UIColor = UIColor.black.withAlphaComponent(0.8)) {
+                shadowColor: UIColor = UIColor.black.withAlphaComponent(0.8),
+                image: UIImage? = nil,
+                imageTintColor: UIColor? = nil,
+                imageInsets: UIEdgeInsets = .zero) {
         self.size = size
         self.color = color
         self.shadowBlur = shadowBlur
         self.shadowOffset = shadowOffset
         self.shadowColor = shadowColor
+        self.image = image
+        self.imageTintColor = imageTintColor
+        self.imageInsets = imageInsets
     }
 }
 


### PR DESCRIPTION
This pull request adds support for specifying custom knob paths. So instead of always having oval knobs, users can now for example draw polygons, squares, ... .

This pull request also adds support for drawing images in knobs, by allowing the user to specify both the image, insets and tint color.

This allows for some very nice effects, such as ![this](https://user-images.githubusercontent.com/1745504/64856472-53857c80-d622-11e9-904d-3055322965f3.jpeg)
