### PR TITLE
UICircularProgressRing.swift documentation fix

### DIFF
--- a/src/UICircularProgressRing/UICircularProgressRing.swift
+++ b/src/UICircularProgressRing/UICircularProgressRing.swift
@@ -100,7 +100,7 @@ final public class UICircularProgressRing: UICircularRing {
      The minimum value for the progress ring. ex: (0) -> 100.
 
      ## Important ##
-     Default = 100
+     Default = 0.0
 
      Must be a non-negative value, the absolute value is taken when setting this property.
 
@@ -120,7 +120,7 @@ final public class UICircularProgressRing: UICircularRing {
      The maximum value for the progress ring. ex: 0 -> (100)
 
      ## Important ##
-     Default = 100
+     Default = 100.0
 
      Must be a non-negative value, the absolute value is taken when setting this property.
 


### PR DESCRIPTION
UICircularProgressRing.swift documentation fix
- Fix documentation of minValue property default value from 100 to 0.0
- Fix documentation of maxValue property default value from 100 to 100.0